### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Upload JAR to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: build/libs/!(*-sources).jar


### PR DESCRIPTION
Closes #18 
 
### Changes

- Add `.github/workflows/release.yml`
- Triggers on `release: created` and builds the project and attaches the JAR to the existing release
- Excludes the `-sources.jar` from the upload
- Uses the same Java 25 + Gradle setup as the build workflow

### How it works

1. You create a release via the GitHub UI as usual (I assume)
2. The workflow triggers, builds the project from the tagged commit
3. The built JAR (e.g. `adaptiveview-2.4.3+26.1.jar`) is automatically attached to the release
No change to the existing release process: it just automates the JAR upload.
